### PR TITLE
Fix: Declared dynamic properties to avoid deprecation warning in PHP 8.3

### DIFF
--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -39,8 +39,8 @@ class Plugin {
 
 	public $dependence_manager;
 
-	public $isset_jet_popup = true;
-	public $isset_elementor_pro = true;
+	public $isset_jet_popup = false;
+	public $isset_elementor_pro = false;
 
 	private function __construct() {
 


### PR DESCRIPTION
- Added private properties isset_jet_popup and isset_elementor_pro to Dependency_Manager class.
- Prevented dynamic property creation warnings in check_simple_present and show_simple_warnings methods.